### PR TITLE
[Ubuntu] Phase 6: Production deployment configuration

### DIFF
--- a/docs/PRODUCTION_RUNBOOK.md
+++ b/docs/PRODUCTION_RUNBOOK.md
@@ -1,0 +1,61 @@
+# Production Runbook
+
+## Deployment
+
+1. **Deploy the production stack:**
+   ```bash
+   bash scripts/deploy_production.sh
+   ```
+
+2. **Verify deployment:**
+   ```bash
+   docker ps
+   redis-cli PING
+   ```
+
+## Health Checks
+
+- **Redis health:** `docker exec a2a-redis redis-cli PING`
+- **AI Connector logs:** `docker logs a2a-ai-connector`
+- **Container status:** `docker ps --filter "name=a2a"`
+
+## Monitoring
+
+- Redis metrics: `docker exec a2a-redis redis-cli INFO`
+- Container resource usage: `docker stats a2a-redis a2a-ai-connector`
+
+## Backup
+
+1. **Trigger Redis backup:**
+   ```bash
+   redis-cli BGSAVE
+   ```
+
+2. **Check backup status:**
+   ```bash
+   redis-cli LASTSAVE
+   ```
+
+3. **Backup location:** `/data/dump.rdb` inside the Redis container
+
+## Rollback
+
+If issues occur:
+
+1. **Stop production stack:**
+   ```bash
+   cd infra/broker
+   docker compose -f docker-compose-broker.yml -f docker-compose.prod.yml down
+   ```
+
+2. **Restore previous version:**
+   ```bash
+   git checkout <previous-version>
+   bash scripts/deploy_production.sh
+   ```
+
+## Troubleshooting
+
+- **Redis connection issues:** Check firewall rules and ensure port 6379 is accessible
+- **AI Connector not processing:** Check logs with `docker logs a2a-ai-connector`
+- **High memory usage:** Monitor with `docker stats` and adjust Redis maxmemory if needed

--- a/infra/broker/README.md
+++ b/infra/broker/README.md
@@ -15,3 +15,9 @@ Starting the broker with Docker Compose will also launch the Redis-backed AI Con
 ```bash
 docker compose -f docker-compose-broker.yml down
 ```
+
+## Production Deployment
+
+```bash
+docker compose -f docker-compose-broker.yml -f docker-compose.prod.yml up -d
+```

--- a/infra/broker/docker-compose.prod.yml
+++ b/infra/broker/docker-compose.prod.yml
@@ -1,0 +1,19 @@
+version: '3.8'
+
+services:
+  redis:
+    volumes:
+      - redis_prod_data:/data
+    environment:
+      - REDIS_LOG_LEVEL=warning
+    restart: always
+
+  ai-connector:
+    environment:
+      - LOG_LEVEL=info
+      - PRODUCTION=true
+    restart: always
+
+volumes:
+  redis_prod_data:
+    name: a2a_redis_prod_data

--- a/scripts/deploy_production.sh
+++ b/scripts/deploy_production.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+echo "🚀 Starting production deployment..."
+
+# Ensure we're in the right directory
+cd "$(dirname "$0")/.."
+
+# Build the AI Connector image
+echo "📦 Building AI Connector image..."
+docker build -t a2a-ai-connector:latest -f agents/ai_connector.Dockerfile .
+
+# Deploy the production stack
+echo "🔧 Deploying production stack..."
+cd infra/broker
+docker compose -f docker-compose-broker.yml -f docker-compose.prod.yml up -d
+
+# Wait for services to be healthy
+echo "⏳ Waiting for services to be healthy..."
+sleep 5
+
+# Check Redis health
+echo "🏥 Checking Redis health..."
+docker exec a2a-redis redis-cli PING
+
+echo "✅ Production deployment complete!"


### PR DESCRIPTION
## Summary
- Add production deployment configuration for a2a-system
- Implement Codex's Phase 6 production files

## Changes
- `docker-compose.prod.yml`: Production overrides with persistent volume and restart policies
- `scripts/deploy_production.sh`: Automated deployment script
- `infra/broker/README.md`: Added production deployment instructions
- `docs/PRODUCTION_RUNBOOK.md`: Comprehensive runbook with health checks, monitoring, backup, and rollback procedures

## Files from Codex
This PR implements the files created by Codex for Phase 6 production deployment.

## Test plan
- [ ] Merge PR
- [ ] DevOps team runs `bash scripts/deploy_production.sh`
- [ ] Verify with `docker ps` and `redis-cli PING`
- [ ] UC monitors health endpoint every 2 min for 10 min
- [ ] UC verifies Redis backup after 30 min

🤖 Generated with [Claude Code](https://claude.ai/code)